### PR TITLE
tracer: fix tracer names in Init godoc comments

### DIFF
--- a/tracer/dockeropenbreakout/dockeropenbreakout.go
+++ b/tracer/dockeropenbreakout/dockeropenbreakout.go
@@ -95,7 +95,7 @@ type bpftracer struct {
 	dockerClient *client.Client
 }
 
-// Init returns a new bashreadline tracer.
+// Init returns a new dockerbreakout tracer.
 func Init() (tracer.Tracer, error) {
 	// Create the docker client.
 	c, err := client.NewEnvClient()

--- a/tracer/exec/exec.go
+++ b/tracer/exec/exec.go
@@ -143,7 +143,7 @@ type bpftracer struct {
 	argv    map[uint32][]string
 }
 
-// Init returns a new bashreadline tracer.
+// Init returns a new exec tracer.
 func Init() (tracer.Tracer, error) {
 	return &bpftracer{
 		channel: make(chan []byte),

--- a/tracer/open/open.go
+++ b/tracer/open/open.go
@@ -92,7 +92,7 @@ type bpftracer struct {
 	channel chan []byte
 }
 
-// Init returns a new bashreadline tracer.
+// Init returns a new open tracer.
 func Init() (tracer.Tracer, error) {
 	return &bpftracer{
 		channel: make(chan []byte),

--- a/tracer/tcpdrop/tcpdrop.go
+++ b/tracer/tcpdrop/tcpdrop.go
@@ -163,7 +163,7 @@ type bpftracer struct {
 	channel chan []byte
 }
 
-// Init returns a new bashreadline tracer.
+// Init returns a new tcpdrop tracer.
 func Init() (tracer.Tracer, error) {
 	return &bpftracer{
 		channel: make(chan []byte),


### PR DESCRIPTION
These were probably copy-pasted from the bashreadline tracer originally.
Adjust them to reflect the actual tracer name.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>