### PR TITLE
Fix staticcheck errors

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -82,7 +82,7 @@ func NewServer(ctx context.Context, opt Opts) (grpc.APIServer, error) {
 				}
 				event.Tracer = p
 
-				progRules, _ := server.rules[p]
+				progRules := server.rules[p]
 
 				if len(progRules) < 1 {
 					// Just send to stdout and be done with it.

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -410,12 +410,7 @@ func GetNoNewPrivileges(pid int) bool {
 }
 
 func getNoNewPrivileges(input string) bool {
-	nnp := getStatusEntry(input, "NoNewPrivs:")
-	if nnp == "1" {
-		return true
-	}
-
-	return false
+	return getStatusEntry(input, "NoNewPrivs:") == "1"
 }
 
 // GetCmdline returns the cmdline for a process.

--- a/proc/proc_test.go
+++ b/proc/proc_test.go
@@ -6,7 +6,6 @@ import (
 
 func TestGetContainerIDAndRuntime(t *testing.T) {
 	testcases := map[string]struct {
-		name            string
 		expectedRuntime ContainerRuntime
 		expectedID      string
 		input           string
@@ -170,7 +169,6 @@ func TestGetUserMappings(t *testing.T) {
 
 func TestGetSeccompEnforceMode(t *testing.T) {
 	testcases := map[string]struct {
-		name          string
 		expectedModes []SeccompMode
 		input         string
 	}{
@@ -320,7 +318,6 @@ nonvoluntary_ctxt_switches:     1`,
 
 func TestGetNoNewPrivileges(t *testing.T) {
 	testcases := map[string]struct {
-		name     string
 		expected bool
 		input    string
 	}{
@@ -432,7 +429,6 @@ nonvoluntary_ctxt_switches:     1`,
 
 func TestGetUIDGID(t *testing.T) {
 	testcases := map[string]struct {
-		name        string
 		expectedUID uint32
 		expectedGID uint32
 		input       string


### PR DESCRIPTION
Fix the following staticcheck errors:

  api/api.go:85:5: should write progRules := server.rules[p] instead of progRules, _ := server.rules[p] (S1005)
  proc/proc.go:414:2: should use 'return <expr>' instead of 'if <expr> { return <bool> }; return <bool>' (S1008)
  proc/proc_test.go:9:3: field name is unused (U1000)
  proc/proc_test.go:173:3: field name is unused (U1000)
  proc/proc_test.go:323:3: field name is unused (U1000)
  proc/proc_test.go:435:3: field name is unused (U1000)

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>